### PR TITLE
consider strictVariables when auto configuring default pebble engine

### DIFF
--- a/src/main/java/com/mitchellbosecke/pebble/boot/autoconfigure/PebbleAutoConfiguration.java
+++ b/src/main/java/com/mitchellbosecke/pebble/boot/autoconfigure/PebbleAutoConfiguration.java
@@ -79,6 +79,7 @@ public class PebbleAutoConfiguration {
             if (this.properties.getDefaultLocale() != null) {
                 builder.defaultLocale(this.properties.getDefaultLocale());
             }
+            builder.strictVariables(this.properties.isStrictVariables());
             return builder.build();
         }
     }

--- a/src/main/java/com/mitchellbosecke/pebble/boot/autoconfigure/PebbleProperties.java
+++ b/src/main/java/com/mitchellbosecke/pebble/boot/autoconfigure/PebbleProperties.java
@@ -33,6 +33,8 @@ public class PebbleProperties {
 
     private Locale defaultLocale;
 
+    private boolean strictVariables = false;
+
     public String getPrefix() {
         return this.prefix;
     }
@@ -97,4 +99,11 @@ public class PebbleProperties {
         this.defaultLocale = defaultLocale;
     }
 
+    public boolean isStrictVariables() {
+        return strictVariables;
+    }
+
+    public void setStrictVariables(boolean strictVariables) {
+        this.strictVariables = strictVariables;
+    }
 }


### PR DESCRIPTION
The default pebble engine configuration does not take into account strictVariables setting.
In development/local environment is so useful to enable it, but with the default auto configuration I cannot set it via property file (like cache property which I put to false when working in templates) without overriding the bean PebbleEngine